### PR TITLE
runelite: save screenshots somewhere more user-accessible

### DIFF
--- a/com.jagex.Launcher.ThirdParty.RuneLite.yaml
+++ b/com.jagex.Launcher.ThirdParty.RuneLite.yaml
@@ -73,3 +73,8 @@ modules:
           if ! grep -q "RuneLite Launcher_is1" "${WINEPREFIX}/user.reg"; then
             /app/wine/bin/wine reg.exe add "HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\RuneLite Launcher_is1" /v "InstallLocation" /t REG_SZ /d "Z:\\app\\ThirdParty\\RuneLite" /f
           fi
+          export XDG_PICTURES_DIR="${XDG_PICTURES_DIR:-${HOME}/Pictures}"
+          mkdir -p ${XDG_PICTURES_DIR}/RuneLite
+          mv ${XDG_DATA_HOME}/../.runelite/screenshots/* ${XDG_PICTURES_DIR}/RuneLite || true
+          rm -rf ${XDG_DATA_HOME}/../.runelite/screenshots
+          ln -sf ${XDG_PICTURES_DIR}/RuneLite ${XDG_DATA_HOME}/../.runelite/screenshots

--- a/com.jagex.Launcher.yaml
+++ b/com.jagex.Launcher.yaml
@@ -24,6 +24,7 @@ finish-args:
   - --env=WINEDLLOVERRIDES=dxgi=b # Fix launch on Steam Deck by using builtin dxgi
   - --env=GST_PLUGIN_SYSTEM_PATH=/app/lib32/gstreamer-1.0:/app/lib/gstreamer-1.0:/usr/lib/i386-linux-gnu/gstreamer-1.0:/usr/lib/x86_64-linux-gnu/gstreamer-1.0
   - --talk-name=org.freedesktop.Notifications
+  - --filesystem=xdg-pictures/RuneLite:create
 sdk-extensions:
   - org.freedesktop.Sdk.Compat.i386
 add-extensions:


### PR DESCRIPTION
After this change screenshots will be moved to the user's `$HOME/Pictures/RuneLite` directory and future screenshots will be saved here

Fixes #43 